### PR TITLE
Add support for user params in precursor tags

### DIFF
--- a/io/MzML/pom.xml
+++ b/io/MzML/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>se.lth.immun</groupId>
 			<artifactId>Xml</artifactId>
-			<version>1.2.1</version>
+			<version>1.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>se.lth.immun</groupId>

--- a/io/MzML/src/main/scala/se/lth/immun/mzml/Precursor.scala
+++ b/io/MzML/src/main/scala/se/lth/immun/mzml/Precursor.scala
@@ -28,7 +28,9 @@ object Precursor {
 				}
 				case ACTIVATION => 
 					x.activation = Activation.fromFile(r)
-				case _ => r.skipThis
+				case USER_PARAM => 
+					x.userParams += UserParam.fromFile(r)
+				case _ => { r.skipThis; r.next } 
 			}
 		
 		x
@@ -39,6 +41,7 @@ class Precursor {
 	var externalSpectrumID:Option[String] = None
 	var sourceFileRef:Option[String] = None
 	var spectrumRef:Option[String] = None
+	var userParams = new ArrayBuffer[UserParam]
 	
 	var isolationWindow:Option[IsolationWindow] = None
 	var selectedIons = new ArrayBuffer[SelectedIon]
@@ -52,6 +55,8 @@ class Precursor {
 		w.writeOptional(EXTERNAL_SPECTRUM_ID, externalSpectrumID)
 		w.writeOptional(SOURCE_FILE_REF, sourceFileRef)
 		w.writeOptional(SPECTRUM_REF, spectrumRef)
+		
+		for (x <- userParams) x.write(w)
 		
 		if (isolationWindow.isDefined)
 			isolationWindow.get.write(w)

--- a/io/Xml/pom.xml
+++ b/io/Xml/pom.xml
@@ -6,7 +6,7 @@
   <version>1.3.0</version>
   <inceptionYear>2014</inceptionYear>
   <properties>
-    <scala.version>2.10.0</scala.version>
+    <scala.version>2.10.3</scala.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fixes problems with recent ProteoWizard mzML output, see https://github.com/statisticalbiotechnology/quandenser/issues/20.

The problem was that user_param was not in the switch-case statement and we ended up in an infinite loop due to
`case _ => r.skipThis`. In some other files (e.g. ChromatogramList.scala)this was handled as `case _ => { r.skipThis; r.next }`. This change actually prevents the infinite loop and seems to be the desired behavior. Do you remember if there was a reason for the difference between the files, or should all `case _ => r.skipThis` be converted to `case _ => { r.skipThis; r.next }`?