### PR TITLE
Fix Xml package versions in Graphs and TraML packages

### DIFF
--- a/Graphs/pom.xml
+++ b/Graphs/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>se.lth.immun</groupId>
   <artifactId>Graphs</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   
   <inceptionYear>2011</inceptionYear>
   <properties>
@@ -33,7 +33,7 @@
     <dependency>
     	<groupId>se.lth.immun</groupId>
     	<artifactId>Xml</artifactId>
-    	<version>1.0.0</version>
+    	<version>1.3.1</version>
     </dependency>
     <dependency>
     	<groupId>org.scala-lang</groupId>

--- a/io/TraML/pom.xml
+++ b/io/TraML/pom.xml
@@ -3,6 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>se.lth.immun</groupId>
   <artifactId>TraML</artifactId>
+  <version>2.0.2</version>
+  
   <inceptionYear>2014</inceptionYear>
   <properties>
     <scala.version>2.10.0</scala.version>
@@ -32,7 +34,7 @@
     <dependency>
     	<groupId>se.lth.immun</groupId>
     	<artifactId>Xml</artifactId>
-    	<version>1.3.0</version>
+    	<version>1.3.1</version>
     </dependency>
   </dependencies>
 
@@ -82,5 +84,4 @@
       </plugin>
     </plugins>
   </build>
-  <version>2.0.1</version>
 </project>


### PR DESCRIPTION
Getting this error when trying to build Dinosaur:
```
Error:  Failed to execute goal on project Dinosaur: Could not resolve dependencies for project se.lth.immun:Dinosaur:jar:1.2.0: 
Failed to collect dependencies at se.lth.immun:Graphs:jar:1.0.0 -> se.lth.immun:Xml:jar:1.0.0: 
Failed to read artifact descriptor for se.lth.immun:Xml:jar:1.0.0: 
Could not transfer artifact se.lth.immun:Xml:pom:1.0.0 from/to maven-default-http-blocker (http://0.0.0.0/): 
Blocked mirror for repositories: [scala-tools.org (http://scala-tools.org/repo-releases, default, releases+snapshots)] -> [Help 1]
```
Apparently, there is no 1.0.0 version of the Xml package in the maven repository (this doesn't exist: https://repo.maven.apache.org/maven2/se/lth/immun/Xml/1.0.0/Xml-1.0.0.pom). 

I bumped the Xml package version for the Graphs and TraML packages, that should resolve the problem.

Not sure why Maven suddenly decided that this is a problem after having worked fine for the past years.